### PR TITLE
Remove the workspace tag from the Terraform state read role

### DIFF
--- a/read_terraform_state_role.tf
+++ b/read_terraform_state_role.tf
@@ -12,9 +12,15 @@ module "read_terraform_state" {
     aws.users = aws.users
   }
 
-  account_ids                 = [local.users_account_id]
-  role_name                   = var.read_terraform_state_role_name
-  role_tags                   = var.tags
+  account_ids = [local.users_account_id]
+  role_name   = var.read_terraform_state_role_name
+  # It makes no sense to associate a "Workspace" tag with the
+  # Terraform read role, since it can read the state from any
+  # workspace.
+  #
+  # Such a tag will also flip flop as one switched from staging to
+  # production or vice versa, which is highly annoying.
+  role_tags                   = { for k, v in var.tags : k => v if k != "Workspace" }
   terraform_state_bucket_name = "cisa-cool-terraform-state"
   terraform_state_path        = "cool-userservices-networking/*.tfstate"
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the "Workspace" tag from the role that allows reading of the Terraform state.

## 💭 Motivation and context ##

It makes no sense to associate such a tag with the Terraform read role, since it can read the state from _any_ workspace.

Such a tag will also flip flop as one switches from staging to production or vice versa, which is highly annoying.

This PR is stolen entirely from https://github.com/cisagov/cool-sharedservices-networking/pull/46, so thanks @jsf9k! 

## 🧪 Testing ##

I applied these changes to our staging COOL environment and verified that they functioned as expected; also, all `pre-commit` hooks pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
