### PR TITLE
Remove role_tags from cisagov/terraform-state-read-role-tf-module configuration

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -28,12 +28,21 @@ provider "aws" {
 
 # The provider used to create resources inside the Terraform account.
 provider "aws" {
-  alias  = "terraformprovisionaccount"
-  region = var.aws_region
+  alias = "terraformprovisionaccount"
   assume_role {
     role_arn     = data.terraform_remote_state.terraform.outputs.provisionaccount_role.arn
     session_name = local.caller_user_name
   }
+  default_tags {
+    # It makes no sense to associate a "Workspace" tag with the
+    # Terraform read role, since it can read the state from any
+    # workspace.
+    #
+    # Such a tag will also flip flop as one switched from staging to
+    # production or vice versa, which is highly annoying.
+    tags = { for k, v in var.tags : k => v if k != "Workspace" }
+  }
+  region = var.aws_region
 }
 
 # The provider used to create resources inside the Users account.

--- a/read_terraform_state_role.tf
+++ b/read_terraform_state_role.tf
@@ -12,15 +12,8 @@ module "read_terraform_state" {
     aws.users = aws.users
   }
 
-  account_ids = [local.users_account_id]
-  role_name   = var.read_terraform_state_role_name
-  # It makes no sense to associate a "Workspace" tag with the
-  # Terraform read role, since it can read the state from any
-  # workspace.
-  #
-  # Such a tag will also flip flop as one switched from staging to
-  # production or vice versa, which is highly annoying.
-  role_tags                   = { for k, v in var.tags : k => v if k != "Workspace" }
+  account_ids                 = [local.users_account_id]
+  role_name                   = var.read_terraform_state_role_name
   terraform_state_bucket_name = "cisa-cool-terraform-state"
   terraform_state_path        = "cool-userservices-networking/*.tfstate"
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Terraform code to remove `role_tags` from the [cisagov/terraform-state-read-role-tf-module](https://github.com/cisagov/terraform-state-read-role-tf-module) configuration.

## 💭 Motivation and context ##

This is in accordance with the changes in cisagov/terraform-state-read-role-tf-module#5.

Note that `var.tags` (minus the `Workspace` tag, if present) is passed in via the provider's default tags, so there is no need to use `additional_role_tags` here.

## 🧪 Testing ##

I ran a `terraform apply` with this new code against our COOL environments.  Terraform only wanted to add tags to an extant IAM policy resource, which was expected.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
